### PR TITLE
GH-28: fix blocking issue

### DIFF
--- a/GbxRemote.Net/XmlRpc/NadeoXmlRpcClient.cs
+++ b/GbxRemote.Net/XmlRpc/NadeoXmlRpcClient.cs
@@ -149,8 +149,23 @@ namespace GbxRemoteNet.XmlRpc
 
             logger.Debug("Client connected to XML-RPC server with IP: {connectAddr}", connectAddr);
 
+            // Cancellation token to cancel task if it takes longer than a second
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(1000);
+            
             // check header
-            ConnectHeader header = await ConnectHeader.FromIOAsync(xmlRpcIO);
+            ConnectHeader header = null;
+            try
+            {
+                header = await ConnectHeader.FromIOAsync(xmlRpcIO, cancellationTokenSource.Token);
+            }
+            catch (Exception e)
+            {
+                logger.Error(e, $"Exception occured when trying to get connect header: {e.Message}");
+                logger.Error("Failed to get connect header.");
+                return false;
+            }
+            
             if (!header.IsValid)
             {
                 logger.Error("Client is using an invalid header protocol: {header.protocol}", header.Protocol);

--- a/GbxRemote.Net/XmlRpc/Packets/ConnectHeader.cs
+++ b/GbxRemote.Net/XmlRpc/Packets/ConnectHeader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GbxRemoteNet.XmlRpc.Packets {
@@ -20,7 +21,14 @@ namespace GbxRemoteNet.XmlRpc.Packets {
         public static async Task<ConnectHeader> FromIOAsync(XmlRpcIO io) {
             int length = BitConverter.ToInt32(await io.ReadBytesAsync(4));
             string protocol = Encoding.ASCII.GetString(await io.ReadBytesAsync(length));
-
+            
+            return new ConnectHeader(length, protocol);
+        }
+        
+        public static async Task<ConnectHeader> FromIOAsync(XmlRpcIO io, CancellationToken cancellationToken) {
+            int length = BitConverter.ToInt32(await io.ReadBytesAsync(4, cancellationToken));
+            string protocol = Encoding.ASCII.GetString(await io.ReadBytesAsync(length, cancellationToken));
+            
             return new ConnectHeader(length, protocol);
         }
 

--- a/GbxRemote.Net/XmlRpc/XmlRpcIO.cs
+++ b/GbxRemote.Net/XmlRpc/XmlRpcIO.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GbxRemoteNet.XmlRpc
@@ -48,6 +49,26 @@ namespace GbxRemoteNet.XmlRpc
             while (n - count > 0)
             {
                 count += await stream.ReadAsync(data.AsMemory(count, n - count));
+            }
+            return data;
+        }
+        
+        /// <summary>
+        /// Read a specific number of bytes from the connection.
+        /// This method will always read exactly n amount of bytes, so
+        /// if there is nothing to read until the number of bytes to read
+        /// is fulfilled, it will block.
+        /// </summary>
+        /// <param name="n">Number of bytes to read.</param>
+        /// <param name="token">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
+        /// <returns>The bytes that was read from the connection.</returns>
+        public async Task<byte[]> ReadBytesAsync(int n, CancellationToken token)
+        {
+            byte[] data = new byte[n];
+            int count = 0;
+            while (n - count > 0)
+            {
+                count += await stream.ReadAsync(data.AsMemory(count, n - count), token);
             }
             return data;
         }


### PR DESCRIPTION
- [x] Implement cancellation token for XmlRpcIo ReadBytesAsync as it can block.
- [x] Cancel trying to get the connect headers after 1 second

This should prevent the library from being blocked if no remote access is allowed.
Would like review before being merged.