### PR TITLE
Fix ChatEnableManualRouting calling wrong method.

### DIFF
--- a/src/GbxRemote.Net/GbxRemoteClient.Methods.Chat.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Methods.Chat.cs
@@ -136,10 +136,10 @@ public partial class GbxRemoteClient
     /// <param name="enable"></param>
     /// <param name="forward"></param>
     /// <returns></returns>
-    public async Task<bool> ChatEnableManualRoutingAsync(bool enable, bool forward)
+    public async Task<bool> ChatEnableManualRoutingAsync(bool enable=true, bool forward=false)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
-            await CallOrFaultAsync("ChatSendToId", enable, forward)
+            await CallOrFaultAsync("ChatEnableManualRouting", enable, forward)
         );
     }
 


### PR DESCRIPTION
The `ChatEnableManualRoutingAsync` was calling the wrong method, resulting in an XMLRPC fault. I also added default parameters which simplifies the code.