### PR TITLE
Update gbxremote api

### DIFF
--- a/src/Examples/CallbackExample/Program.cs
+++ b/src/Examples/CallbackExample/Program.cs
@@ -54,13 +54,13 @@ internal class Program
         WaitHandle.WaitAny(new[] {cancelToken.Token.WaitHandle});
     }
 
-    private static Task ClientOnOnMapListModified(object sender, MapListModifiedEventArgs e)
+    private static Task ClientOnOnMapListModified(object sender, MapListModifiedGbxEventArgs e)
     {
         Console.WriteLine("Map list modified.");
         return Task.CompletedTask;
     }
 
-    private static Task ClientOnOnPlayerManialinkPageAnswer(object sender, ManiaLinkPageActionEventArgs e)
+    private static Task ClientOnOnPlayerManialinkPageAnswer(object sender, ManiaLinkPageActionGbxEventArgs e)
     {
         Console.WriteLine($"Player page answer: {e.PlayerId} | {e.Login}, Answer: {e.Answer}");
         return Task.CompletedTask;
@@ -79,31 +79,31 @@ internal class Program
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnPlayerInfoChanged(object sender, PlayerInfoChangedEventArgs e)
+    private static Task Client_OnPlayerInfoChanged(object sender, PlayerInfoChangedGbxEventArgs e)
     {
         Console.WriteLine($"Player info changed for: {e.PlayerInfo.NickName}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnStatusChanged(object sender, StatusChangedEventArgs e)
+    private static Task Client_OnStatusChanged(object sender, StatusChangedGbxEventArgs e)
     {
         Console.WriteLine($"[Status Changed] {e.StatusCode}: {e.StatusName}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnEndMap(object sender, MapEventArgs e)
+    private static Task Client_OnEndMap(object sender, MapGbxEventArgs e)
     {
         Console.WriteLine($"End map: {e.Map.Name}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnBeginMap(object sender, MapEventArgs e)
+    private static Task Client_OnBeginMap(object sender, MapGbxEventArgs e)
     {
         Console.WriteLine($"Begin map: {e.Map.Name}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnEndMatch(object sender, EndMatchEventArgs e)
+    private static Task Client_OnEndMatch(object sender, EndMatchGbxEventArgs e)
     {
         Console.WriteLine("Match ended, rankings:");
         foreach (var ranking in e.Rankings)
@@ -118,31 +118,31 @@ internal class Program
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnEcho(object sender, EchoEventArgs e)
+    private static Task Client_OnEcho(object sender, EchoGbxEventArgs e)
     {
         Console.WriteLine($"[Echo] internal: {e.InternalParam}, public: {e.InternalParam}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnPlayerChat(object sender, PlayerChatEventArgs e)
+    private static Task Client_OnPlayerChat(object sender, PlayerChatGbxEventArgs e)
     {
         Console.WriteLine($"[Chat] {e.Login}: {e.Text}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnPlayerDisconnect(object sender, PlayerDisconnectEventArgs e)
+    private static Task Client_OnPlayerDisconnect(object sender, PlayerDisconnectGbxEventArgs e)
     {
         Console.WriteLine($"Player disconnected: {e.Login}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnPlayerConnect(object sender, PlayerConnectEventArgs e)
+    private static Task Client_OnPlayerConnect(object sender, PlayerConnectGbxEventArgs e)
     {
         Console.WriteLine($"Player connected: {e.Login}");
         return Task.CompletedTask;
     }
 
-    private static Task Client_OnAnyCallback(object sender, CallbackEventArgs<object> e)
+    private static Task Client_OnAnyCallback(object sender, CallbackGbxEventArgs<object> e)
     {
         Console.WriteLine($"[Any callback] {e.Call.Method}:");
         foreach (var par in e.Parameters) Console.WriteLine($"- {par}");

--- a/src/Examples/CallbackExample/Program.cs
+++ b/src/Examples/CallbackExample/Program.cs
@@ -17,7 +17,7 @@ internal class Program
     private static async Task Main(string[] args)
     {
         // create client instance
-        GbxRemoteClient client = new("127.0.0.1", 5001, Logger.New<Program>(LogLevel.Debug));
+        GbxRemoteClient client = new("172.25.112.179", 5000, Logger.New<Program>(LogLevel.Debug));
 
         // connect and login
         if (!await client.LoginAsync("SuperAdmin", "SuperAdmin"))

--- a/src/Examples/CallbackExample/Program.cs
+++ b/src/Examples/CallbackExample/Program.cs
@@ -17,7 +17,7 @@ internal class Program
     private static async Task Main(string[] args)
     {
         // create client instance
-        GbxRemoteClient client = new("172.25.112.179", 5000, Logger.New<Program>(LogLevel.Debug));
+        GbxRemoteClient client = new("127.0.0.1", 5001, Logger.New<Program>(LogLevel.Debug));
 
         // connect and login
         if (!await client.LoginAsync("SuperAdmin", "SuperAdmin"))

--- a/src/GbxRemote.Net.Tests/XmlRpcTests/ExtraTypesTests/Base64Tests.cs
+++ b/src/GbxRemote.Net.Tests/XmlRpcTests/ExtraTypesTests/Base64Tests.cs
@@ -6,7 +6,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.ExtraTypesTests {
     public class Base64Tests {
         [Fact]
         public void Base64_String_Constructor_Correctly_Encodes_Bytes() {
-            Base64 base64 = new("Test Input");
+            GbxBase64 base64 = new("Test Input");
 
             Assert.Equal(
                 new byte[] { 0x54, 0x65, 0x73, 0x74, 0x20, 0x49, 0x6e, 0x70, 0x75, 0x74 }, 
@@ -16,7 +16,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.ExtraTypesTests {
 
         [Fact]
         public void Base64_FromBase64String_Parses_Correctly() {
-            Base64 base64 = Base64.FromBase64String("VGVzdCBJbnB1dA==");
+            GbxBase64 base64 = GbxBase64.FromBase64String("VGVzdCBJbnB1dA==");
 
             Assert.Equal(
                 new byte[] { 0x54, 0x65, 0x73, 0x74, 0x20, 0x49, 0x6e, 0x70, 0x75, 0x74 },
@@ -26,7 +26,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.ExtraTypesTests {
 
         [Fact]
         public void Base64_Correctly_Encodes_Into_Base64() {
-            Base64 base64 = new("Test Input");
+            GbxBase64 base64 = new("Test Input");
 
             string result = base64.ToString();
 

--- a/src/GbxRemote.Net.Tests/XmlRpcTests/TypesTests/GeneralTypesTests.cs
+++ b/src/GbxRemote.Net.Tests/XmlRpcTests/TypesTests/GeneralTypesTests.cs
@@ -14,7 +14,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.TypesTests {
         [InlineData("VGVzdCBTdHJpbmc=", "<base64>VGVzdCBTdHJpbmc=</base64>")]
         [InlineData("", "<base64></base64>")]
         public void XmlRpcBase64_GetXml_Returns_Correct_Element(string input, string expected) {
-            XmlRpcBase64 base64 = new(Base64.FromBase64String(input));
+            GbxRemoteNet.XmlRpc.Types.XmlRpcBase64 base64 = new(GbxBase64.FromBase64String(input));
 
             string xml = base64.GetXml().ToString();
 

--- a/src/GbxRemote.Net.Tests/XmlRpcTests/TypesTests/MultiDataTypesTests.cs
+++ b/src/GbxRemote.Net.Tests/XmlRpcTests/TypesTests/MultiDataTypesTests.cs
@@ -35,10 +35,10 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.TypesTests {
             XmlRpcInteger entry5 = (XmlRpcInteger)array.Values[4];
             XmlRpcDouble entry6 = (XmlRpcDouble)array.Values[5];
             XmlRpcDateTime entry7 = (XmlRpcDateTime)array.Values[6];
-            XmlRpcBase64 entry8 = (XmlRpcBase64)array.Values[7];
+            GbxRemoteNet.XmlRpc.Types.XmlRpcBase64 entry8 = (GbxRemoteNet.XmlRpc.Types.XmlRpcBase64)array.Values[7];
 
             DateTime expectedDateTime = DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime();
-            Base64 expectedBase64 = Base64.FromBase64String("VGVzdCBCYXNlNjQgU3RyaW5n");
+            GbxBase64 expectedBase64 = GbxBase64.FromBase64String("VGVzdCBCYXNlNjQgU3RyaW5n");
 
             Assert.Equal(1, entry1.Value);
             Assert.Equal(2, entry2.Value);
@@ -190,13 +190,13 @@ namespace GbxRemote.Net.Tests.XmlRpcTests.TypesTests {
             string value3 = ((XmlRpcString)strct.Fields["Key3"]).Value;
             bool value4 = ((XmlRpcBoolean)strct.Fields["Key4"]).Value;
             double value5 = ((XmlRpcDouble)strct.Fields["Key5"]).Value;
-            Base64 value6 = ((XmlRpcBase64)strct.Fields["Key6"]).Value;
+            GbxBase64 value6 = ((GbxRemoteNet.XmlRpc.Types.XmlRpcBase64)strct.Fields["Key6"]).Value;
             DateTime value7 = ((XmlRpcDateTime)strct.Fields["Key7"]).Value;
             int value8 = ((XmlRpcInteger)((XmlRpcArray)strct.Fields["Key8"]).Values[0]).Value;
             int value9 = ((XmlRpcInteger)((XmlRpcArray)strct.Fields["Key8"]).Values[1]).Value;
             int value10 = ((XmlRpcInteger)((XmlRpcArray)strct.Fields["Key8"]).Values[2]).Value;
 
-            byte[] expectedValue6 = Base64.FromBase64String("VGVzdCBCYXNlNjQgU3RyaW5n").Data;
+            byte[] expectedValue6 = GbxBase64.FromBase64String("VGVzdCBCYXNlNjQgU3RyaW5n").Data;
             DateTime expectedValue7 = DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime();
 
             Assert.Equal(1, value1);

--- a/src/GbxRemote.Net.Tests/XmlRpcTests/XmlRpcCallTests.cs
+++ b/src/GbxRemote.Net.Tests/XmlRpcTests/XmlRpcCallTests.cs
@@ -32,7 +32,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
                 new XmlRpcString("Test String"),
                 new XmlRpcInteger(123),
                 new XmlRpcDouble(2134.523),
-                new XmlRpcBase64(Base64.FromBase64String("VGVzdCBTdHJpbmc=")),
+                new GbxRemoteNet.XmlRpc.Types.XmlRpcBase64(GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=")),
                 new XmlRpcBoolean(true),
                 new XmlRpcDateTime(DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime()),
                 new XmlRpcArray(new XmlRpcBaseType[] {

--- a/src/GbxRemote.Net.Tests/XmlRpcTests/XmlRpcTypesTests.cs
+++ b/src/GbxRemote.Net.Tests/XmlRpcTests/XmlRpcTypesTests.cs
@@ -28,7 +28,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
             new object[]{ new XElement("boolean", "0"), new XmlRpcBoolean(false) },
             new object[]{ new XElement("double", "34534.1234"), new XmlRpcDouble(34534.1234) },
             new object[]{ new XElement("dateTime.iso8601", "2021-04-06T14:36:44.1557489Z"), new XmlRpcDateTime(DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime()) },
-            new object[]{ new XElement("base64", "VGVzdCBTdHJpbmc="), new XmlRpcBase64(Base64.FromBase64String("VGVzdCBTdHJpbmc=")) },
+            new object[]{ new XElement("base64", "VGVzdCBTdHJpbmc="), new GbxRemoteNet.XmlRpc.Types.XmlRpcBase64(GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=")) },
             new object[]{ new XElement("array", new XElement("data",
                     new XElement("value", new XElement("i4", 1)),
                     new XElement("value", new XElement("int", 2)),
@@ -101,7 +101,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
             new object[]{ new XmlRpcBoolean(false), false },
             new object[]{ new XmlRpcBoolean(true), true },
             new object[]{ new XmlRpcString("Test String"), "Test String" },
-            new object[]{ new XmlRpcBase64(Base64.FromBase64String("VGVzdCBTdHJpbmc=")), Base64.FromBase64String("VGVzdCBTdHJpbmc=") },
+            new object[]{ new GbxRemoteNet.XmlRpc.Types.XmlRpcBase64(GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=")), GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=") },
             new object[]{ new XmlRpcDateTime(DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime()), DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime() },
             new object[]{ new XmlRpcArray(new XmlRpcBaseType[] {
                 new XmlRpcInteger(1),
@@ -114,7 +114,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
                 { "Key2", new XmlRpcInteger(2) },
                 { "Key3", new XmlRpcString("3") },
                 { "Key4", new XmlRpcDouble(4) }
-            }), new DynamicObject(){
+            }), new GbxDynamicObject(){
                 { "Key1", 1 },
                 { "Key2", 2 },
                 { "Key3", "3" },
@@ -134,15 +134,15 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
             XmlRpcStruct str = new(new GbxStruct());
             object result = XmlRpcTypes.ToNativeStruct<object>(str);
 
-            Assert.IsType<DynamicObject>(result);
+            Assert.IsType<GbxDynamicObject>(result);
         }
 
         [Fact]
         public void ToNativeStruct_Returns_DynamicObject_If_DynamicObject_Type() {
             XmlRpcStruct str = new(new GbxStruct());
-            object result = XmlRpcTypes.ToNativeStruct<DynamicObject>(str);
+            object result = XmlRpcTypes.ToNativeStruct<GbxDynamicObject>(str);
 
-            Assert.IsType<DynamicObject>(result);
+            Assert.IsType<GbxDynamicObject>(result);
         }
 
         public class ExampleStruct {
@@ -151,7 +151,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
             public string Field3 { get; set; }
             public bool Field4 { get; set; }
             public bool Field5 { get; set; }
-            public Base64 Field6 { get; set; }
+            public GbxBase64 Field6 { get; set; }
             public DateTime Field7 { get; set; }
             public int[] Field8 { get; set; }
             public ExampleSubStruct Field9 { get; set; }
@@ -170,7 +170,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
                 { "Field3", new XmlRpcString("Test String") },
                 { "Field4", new XmlRpcBoolean(true) },
                 { "Field5", new XmlRpcBoolean(false) },
-                { "Field6", new XmlRpcBase64(Base64.FromBase64String("VGVzdCBTdHJpbmc=")) },
+                { "Field6", new GbxRemoteNet.XmlRpc.Types.XmlRpcBase64(GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=")) },
                 { "Field7", new XmlRpcDateTime(DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime()) },
                 { "Field8", new XmlRpcArray(new XmlRpcBaseType[]{ 
                     new XmlRpcInteger(1),
@@ -186,7 +186,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
 
             ExampleStruct result = (ExampleStruct)XmlRpcTypes.ToNativeStruct<ExampleStruct>(str);
 
-            Base64 field6Expected = Base64.FromBase64String("VGVzdCBTdHJpbmc=");
+            GbxBase64 field6Expected = GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=");
             DateTime field7Expected = DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime();
 
             Assert.NotNull(result);
@@ -258,7 +258,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
             new object[]{ 734.267, new XmlRpcDouble(734.267) },
             new object[]{ DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime(), new XmlRpcDateTime(DateTime.Parse("2021-04-06T16:36:44.1557489+02:00").ToUniversalTime()) },
             new object[]{ "Test String", new XmlRpcString("Test String") },
-            new object[]{ Base64.FromBase64String("VGVzdCBTdHJpbmc="), new XmlRpcBase64(Base64.FromBase64String("VGVzdCBTdHJpbmc=")) },
+            new object[]{ GbxBase64.FromBase64String("VGVzdCBTdHJpbmc="), new GbxRemoteNet.XmlRpc.Types.XmlRpcBase64(GbxBase64.FromBase64String("VGVzdCBTdHJpbmc=")) },
             new object[]{ new int[] { 1, 2, 3 }, new XmlRpcArray(new XmlRpcBaseType[] { 
                 new XmlRpcInteger(1),
                 new XmlRpcInteger(2),
@@ -299,7 +299,7 @@ namespace GbxRemote.Net.Tests.XmlRpcTests {
         [Fact]
         public void DynamicObject_To_XmlRpcStruct()
         {
-            var obj = new DynamicObject();
+            var obj = new GbxDynamicObject();
             
             obj.Add("one", 1);
             obj.Add("two", "two");

--- a/src/GbxRemote.Net/Enums/GbxCallbackType.cs
+++ b/src/GbxRemote.Net/Enums/GbxCallbackType.cs
@@ -3,7 +3,7 @@
 namespace GbxRemoteNet.Enums;
 
 [Flags]
-public enum CallbackType
+public enum GbxCallbackType
 {
     Internal,
     ModeScript,

--- a/src/GbxRemote.Net/Events/BillUpdatedGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/BillUpdatedGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class BillUpdatedEventArgs : EventArgs
+public class BillUpdatedGbxEventArgs : EventArgs
 {
     /// <summary>
     /// ID of the bill.

--- a/src/GbxRemote.Net/Events/CallbackGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/CallbackGbxEventArgs.cs
@@ -3,7 +3,7 @@ using GbxRemoteNet.XmlRpc.Packets;
 
 namespace GbxRemoteNet.Events;
 
-public class CallbackEventArgs<T> : EventArgs
+public class CallbackGbxEventArgs<T> : EventArgs
 {
     public MethodCall Call { get; set; }
     public T[] Parameters { get; set; }

--- a/src/GbxRemote.Net/Events/EchoGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/EchoGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class EchoEventArgs : EventArgs
+public class EchoGbxEventArgs : EventArgs
 {
     /// <summary>
     /// First argument, in-case of a vote, it is the vote message.

--- a/src/GbxRemote.Net/Events/EndMatchGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/EndMatchGbxEventArgs.cs
@@ -3,7 +3,7 @@ using GbxRemoteNet.Structs;
 
 namespace GbxRemoteNet.Events;
 
-public class EndMatchEventArgs : EventArgs
+public class EndMatchGbxEventArgs : EventArgs
 {
     /// <summary>
     /// Array containing the ranking results of the match.

--- a/src/GbxRemote.Net/Events/ManiaLinkPageActionGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/ManiaLinkPageActionGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class ManiaLinkPageActionEventArgs : PlayerEventArgs
+public class ManiaLinkPageActionGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// Player's server ID.

--- a/src/GbxRemote.Net/Events/MapGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/MapGbxEventArgs.cs
@@ -3,7 +3,7 @@ using GbxRemoteNet.Structs;
 
 namespace GbxRemoteNet.Events;
 
-public class MapEventArgs : EventArgs
+public class MapGbxEventArgs : EventArgs
 {
     /// <summary>
     /// Information about the map that will be/was played.

--- a/src/GbxRemote.Net/Events/MapListModifiedGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/MapListModifiedGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class MapListModifiedEventArgs : EventArgs
+public class MapListModifiedGbxEventArgs : EventArgs
 {
     /// <summary>
     /// Index of the current map.

--- a/src/GbxRemote.Net/Events/PlayerChatEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerChatEventArgs.cs
@@ -14,4 +14,9 @@ public class PlayerChatEventArgs : PlayerEventArgs
     /// Whether the message is a command or not.
     /// </summary>
     public bool IsRegisteredCmd { get; set; }
+    /// <summary>
+    /// Chat options that indicates the message channel.
+    /// 0: Default, 1: ToSpectatorCurrent, 2: ToSpectatorAll, 3: ToTeam
+    /// </summary>
+    public int Options { get; set; }
 }

--- a/src/GbxRemote.Net/Events/PlayerChatGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerChatGbxEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace GbxRemoteNet.Events;
 
-public class PlayerChatEventArgs : PlayerEventArgs
+public class PlayerChatGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// The Id of the player on the server.

--- a/src/GbxRemote.Net/Events/PlayerConnectionEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerConnectionEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace GbxRemoteNet.Events;
 
-public class PlayerConnectEventArgs : PlayerEventArgs
+public class PlayerConnectGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// Whether the player is in spectator mode.

--- a/src/GbxRemote.Net/Events/PlayerDisconnectGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerDisconnectGbxEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace GbxRemoteNet.Events;
 
-public class PlayerDisconnectEventArgs : PlayerEventArgs
+public class PlayerDisconnectGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// The reason the player disconnected.

--- a/src/GbxRemote.Net/Events/PlayerGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class PlayerEventArgs : EventArgs
+public class PlayerGbxEventArgs : EventArgs
 {
     /// <summary>
     /// Login name/id of the player.

--- a/src/GbxRemote.Net/Events/PlayerInfoChangedGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/PlayerInfoChangedGbxEventArgs.cs
@@ -3,7 +3,7 @@ using GbxRemoteNet.Structs;
 
 namespace GbxRemoteNet.Events;
 
-public class PlayerInfoChangedEventArgs : EventArgs
+public class PlayerInfoChangedGbxEventArgs : EventArgs
 {
     /// <summary>
     /// New information about the player.

--- a/src/GbxRemote.Net/Events/ScriptCloudGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/ScriptCloudGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class ScriptCloudEventArgs : EventArgs
+public class ScriptCloudGbxEventArgs : EventArgs
 {
     public string Type { get; set; }
     public string Id { get; set; }

--- a/src/GbxRemote.Net/Events/StatusChangedGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/StatusChangedGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class StatusChangedEventArgs : EventArgs
+public class StatusChangedGbxEventArgs : EventArgs
 {
     /// <summary>
     /// Code/ID of the status.

--- a/src/GbxRemote.Net/Events/TunnelDataGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/TunnelDataGbxEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace GbxRemoteNet.Events;
 
-public class TunnelDataEventArgs : PlayerEventArgs
+public class TunnelDataGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// ID of the player on the server.
@@ -11,5 +11,5 @@ public class TunnelDataEventArgs : PlayerEventArgs
     /// <summary>
     /// Data received from the player.
     /// </summary>
-    public Base64 Data { get; set; }
+    public GbxBase64 Data { get; set; }
 }

--- a/src/GbxRemote.Net/Events/VoteUpdatedGbxEventArgs.cs
+++ b/src/GbxRemote.Net/Events/VoteUpdatedGbxEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace GbxRemoteNet.Events;
 
-public class VoteUpdatedEventArgs : PlayerEventArgs
+public class VoteUpdatedGbxEventArgs : PlayerGbxEventArgs
 {
     /// <summary>
     /// Name of the state, can be: NewVote, VoteCancelled, VotePassed or VoteFailed

--- a/src/GbxRemote.Net/GbxRemoteClient.Callbacks.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Callbacks.cs
@@ -182,7 +182,8 @@ public partial class GbxRemoteClient
                     PlayerId = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1]),
                     Text = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[2]),
-                    IsRegisteredCmd = (bool) XmlRpcTypes.ToNativeValue<bool>(call.Arguments[3])
+                    IsRegisteredCmd = (bool) XmlRpcTypes.ToNativeValue<bool>(call.Arguments[3]),
+                    Options = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[4])
                 });
                 break;
             case "ManiaPlanet.Echo":

--- a/src/GbxRemote.Net/GbxRemoteClient.Callbacks.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Callbacks.cs
@@ -19,28 +19,28 @@ public partial class GbxRemoteClient
     /// <summary>
     ///     Triggered for all possible callbacks.
     /// </summary>
-    public event AsyncEventHandler<CallbackEventArgs<object>> OnAnyCallback;
+    public event AsyncEventHandler<CallbackGbxEventArgs<object>> OnAnyCallback;
 
     /// <summary>
     ///     When a player connects to the server.
     /// </summary>
-    public event AsyncEventHandler<PlayerConnectEventArgs> OnPlayerConnect;
+    public event AsyncEventHandler<PlayerConnectGbxEventArgs> OnPlayerConnect;
 
     /// <summary>
     ///     When a player disconnects from the server.
     /// </summary>
-    public event AsyncEventHandler<PlayerDisconnectEventArgs> OnPlayerDisconnect;
+    public event AsyncEventHandler<PlayerDisconnectGbxEventArgs> OnPlayerDisconnect;
 
     /// <summary>
     ///     When a player sends a chat message.
     /// </summary>
-    public event AsyncEventHandler<PlayerChatEventArgs> OnPlayerChat;
+    public event AsyncEventHandler<PlayerChatGbxEventArgs> OnPlayerChat;
 
     /// <summary>
     ///     When a echo message is sent. Can be used for communication with other.
     ///     XMLRPC-clients.
     /// </summary>
-    public event AsyncEventHandler<EchoEventArgs> OnEcho;
+    public event AsyncEventHandler<EchoGbxEventArgs> OnEcho;
 
     /// <summary>
     ///     When the match itself starts, triggered after begin map.
@@ -50,38 +50,38 @@ public partial class GbxRemoteClient
     /// <summary>
     ///     When the match ends, does not give a lot of info in TM2020.
     /// </summary>
-    public event AsyncEventHandler<EndMatchEventArgs> OnEndMatch;
+    public event AsyncEventHandler<EndMatchGbxEventArgs> OnEndMatch;
 
     /// <summary>
     ///     When the map has loaded on the server.
     /// </summary>
-    public event AsyncEventHandler<MapEventArgs> OnBeginMap;
+    public event AsyncEventHandler<MapGbxEventArgs> OnBeginMap;
 
     /// <summary>
     ///     When the map unloads from the server.
     /// </summary>
-    public event AsyncEventHandler<MapEventArgs> OnEndMap;
+    public event AsyncEventHandler<MapGbxEventArgs> OnEndMap;
 
     /// <summary>
     ///     When the server status changed.
     /// </summary>
-    public event AsyncEventHandler<StatusChangedEventArgs> OnStatusChanged;
+    public event AsyncEventHandler<StatusChangedGbxEventArgs> OnStatusChanged;
 
     /// <summary>
     ///     When data about a player changed, it is usually called when
     ///     a player joins or leaves. Gives you more detailed info about a player.
     /// </summary>
-    public event AsyncEventHandler<PlayerInfoChangedEventArgs> OnPlayerInfoChanged;
+    public event AsyncEventHandler<PlayerInfoChangedGbxEventArgs> OnPlayerInfoChanged;
 
     /// <summary>
     ///     When a user triggers the page answer callback from a manialink.
     /// </summary>
-    public event AsyncEventHandler<ManiaLinkPageActionEventArgs> OnPlayerManialinkPageAnswer;
+    public event AsyncEventHandler<ManiaLinkPageActionGbxEventArgs> OnPlayerManialinkPageAnswer;
 
     /// <summary>
     ///     Triggered when the map list changed.
     /// </summary>
-    public event AsyncEventHandler<MapListModifiedEventArgs> OnMapListModified;
+    public event AsyncEventHandler<MapListModifiedGbxEventArgs> OnMapListModified;
 
     /// <summary>
     ///     When the server is about to start.
@@ -96,47 +96,47 @@ public partial class GbxRemoteClient
     /// <summary>
     ///     Tunnel data received from a player.
     /// </summary>
-    public event AsyncEventHandler<TunnelDataEventArgs> OnTunnelDataReceived;
+    public event AsyncEventHandler<TunnelDataGbxEventArgs> OnTunnelDataReceived;
 
     /// <summary>
     ///     When a current vote has been updated.
     /// </summary>
-    public event AsyncEventHandler<VoteUpdatedEventArgs> OnVoteUpdated;
+    public event AsyncEventHandler<VoteUpdatedGbxEventArgs> OnVoteUpdated;
 
     /// <summary>
     ///     When a player bill is updated.
     /// </summary>
-    public event AsyncEventHandler<BillUpdatedEventArgs> OnBillUpdated;
+    public event AsyncEventHandler<BillUpdatedGbxEventArgs> OnBillUpdated;
 
     /// <summary>
     ///     When a player changed allies.
     /// </summary>
-    public event AsyncEventHandler<PlayerEventArgs> OnPlayerAlliesChanged;
+    public event AsyncEventHandler<PlayerGbxEventArgs> OnPlayerAlliesChanged;
 
     /// <summary>
     ///     When a variable from the script cloud is loaded.
     /// </summary>
-    public event AsyncEventHandler<ScriptCloudEventArgs> OnScriptCloudLoadData;
+    public event AsyncEventHandler<ScriptCloudGbxEventArgs> OnScriptCloudLoadData;
 
     /// <summary>
     ///     When a variable from the script cloud is saved.
     /// </summary>
-    public event AsyncEventHandler<ScriptCloudEventArgs> OnScriptCloudSaveData;
+    public event AsyncEventHandler<ScriptCloudGbxEventArgs> OnScriptCloudSaveData;
 
     /// <summary>
     ///     Enable callbacks. If no parameter is provided,
     ///     all callbacks are enabled by default.
     /// </summary>
-    /// <param name="callbackType"></param>
+    /// <param name="gbxCallbackType"></param>
     /// <returns></returns>
     public async Task EnableCallbackTypeAsync(
-        CallbackType callbackType = CallbackType.Internal | CallbackType.ModeScript | CallbackType.Checkpoints)
+        GbxCallbackType gbxCallbackType = GbxCallbackType.Internal | GbxCallbackType.ModeScript | GbxCallbackType.Checkpoints)
     {
-        if (callbackType.HasFlag(CallbackType.Internal))
+        if (gbxCallbackType.HasFlag(GbxCallbackType.Internal))
             await EnableCallbacksAsync(true);
-        if (callbackType.HasFlag(CallbackType.ModeScript))
+        if (gbxCallbackType.HasFlag(GbxCallbackType.ModeScript))
             await TriggerModeScriptEventArrayAsync("XmlRpc.EnableCallbacks", "true");
-        if (callbackType.HasFlag(CallbackType.Checkpoints))
+        if (gbxCallbackType.HasFlag(GbxCallbackType.Checkpoints))
             await TriggerModeScriptEventArrayAsync("Trackmania.Event.SetCurLapCheckpointsMode", "always");
     }
 
@@ -163,21 +163,21 @@ public partial class GbxRemoteClient
         switch (call.Method)
         {
             case "ManiaPlanet.PlayerConnect":
-                await InternalInvokeEventsAsync(OnPlayerConnect?.GetInvocationList(), new PlayerConnectEventArgs
+                await InternalInvokeEventsAsync(OnPlayerConnect?.GetInvocationList(), new PlayerConnectGbxEventArgs
                 {
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     IsSpectator = (bool) XmlRpcTypes.ToNativeValue<bool>(call.Arguments[1])
                 });
                 break;
             case "ManiaPlanet.PlayerDisconnect":
-                await InternalInvokeEventsAsync(OnPlayerDisconnect?.GetInvocationList(), new PlayerDisconnectEventArgs
+                await InternalInvokeEventsAsync(OnPlayerDisconnect?.GetInvocationList(), new PlayerDisconnectGbxEventArgs
                 {
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     Reason = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1])
                 });
                 break;
             case "ManiaPlanet.PlayerChat":
-                await InternalInvokeEventsAsync(OnPlayerChat?.GetInvocationList(), new PlayerChatEventArgs
+                await InternalInvokeEventsAsync(OnPlayerChat?.GetInvocationList(), new PlayerChatGbxEventArgs
                 {
                     PlayerId = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1]),
@@ -187,7 +187,7 @@ public partial class GbxRemoteClient
                 });
                 break;
             case "ManiaPlanet.Echo":
-                await InternalInvokeEventsAsync(OnEcho?.GetInvocationList(), new EchoEventArgs
+                await InternalInvokeEventsAsync(OnEcho?.GetInvocationList(), new EchoGbxEventArgs
                 {
                     InternalParam = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     PublicParam = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1])
@@ -197,33 +197,33 @@ public partial class GbxRemoteClient
                 await InternalInvokeEventsAsync(OnBeginMatch?.GetInvocationList(), new EventArgs());
                 break;
             case "ManiaPlanet.EndMatch":
-                await InternalInvokeEventsAsync(OnEndMatch?.GetInvocationList(), new EndMatchEventArgs
+                await InternalInvokeEventsAsync(OnEndMatch?.GetInvocationList(), new EndMatchGbxEventArgs
                 {
                     Rankings = (TmSPlayerRanking[]) XmlRpcTypes.ToNativeValue<TmSPlayerRanking>(call.Arguments[0]),
                     WinnerTeam = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[1])
                 });
                 break;
             case "ManiaPlanet.BeginMap":
-                await InternalInvokeEventsAsync(OnBeginMap?.GetInvocationList(), new MapEventArgs
+                await InternalInvokeEventsAsync(OnBeginMap?.GetInvocationList(), new MapGbxEventArgs
                 {
                     Map = (TmSMapInfo) XmlRpcTypes.ToNativeValue<TmSMapInfo>(call.Arguments[0])
                 });
                 break;
             case "ManiaPlanet.EndMap":
-                await InternalInvokeEventsAsync(OnEndMap?.GetInvocationList(), new MapEventArgs
+                await InternalInvokeEventsAsync(OnEndMap?.GetInvocationList(), new MapGbxEventArgs
                 {
                     Map = (TmSMapInfo) XmlRpcTypes.ToNativeValue<TmSMapInfo>(call.Arguments[0])
                 });
                 break;
             case "ManiaPlanet.StatusChanged":
-                await InternalInvokeEventsAsync(OnStatusChanged?.GetInvocationList(), new StatusChangedEventArgs
+                await InternalInvokeEventsAsync(OnStatusChanged?.GetInvocationList(), new StatusChangedGbxEventArgs
                 {
                     StatusCode = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     StatusName = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1])
                 });
                 break;
             case "ManiaPlanet.PlayerInfoChanged":
-                await InternalInvokeEventsAsync(OnPlayerInfoChanged?.GetInvocationList(), new PlayerInfoChangedEventArgs
+                await InternalInvokeEventsAsync(OnPlayerInfoChanged?.GetInvocationList(), new PlayerInfoChangedGbxEventArgs
                 {
                     PlayerInfo = (TmSPlayerInfo) XmlRpcTypes.ToNativeValue<TmSPlayerInfo>(call.Arguments[0])
                 });
@@ -235,7 +235,7 @@ public partial class GbxRemoteClient
                 await HandleModeScriptCallback(call);
                 break;
             case "ManiaPlanet.PlayerManialinkPageAnswer":
-                await InternalInvokeEventsAsync(OnPlayerManialinkPageAnswer?.GetInvocationList(), new ManiaLinkPageActionEventArgs
+                await InternalInvokeEventsAsync(OnPlayerManialinkPageAnswer?.GetInvocationList(), new ManiaLinkPageActionGbxEventArgs
                 {
                     PlayerId = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1]),
@@ -244,7 +244,7 @@ public partial class GbxRemoteClient
                 });
                 break;
             case "ManiaPlanet.MapListModified":
-                await InternalInvokeEventsAsync(OnMapListModified?.GetInvocationList(), new MapListModifiedEventArgs
+                await InternalInvokeEventsAsync(OnMapListModified?.GetInvocationList(), new MapListModifiedGbxEventArgs
                 {
                     CurrentMapIndex = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     NextMapIndex = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[1]),
@@ -258,15 +258,15 @@ public partial class GbxRemoteClient
                 await InternalInvokeEventsAsync(OnServerStop?.GetInvocationList(), new EventArgs());
                 break;
             case "ManiaPlanet.TunnelDataReceived":
-                await InternalInvokeEventsAsync(OnTunnelDataReceived?.GetInvocationList(), new TunnelDataEventArgs
+                await InternalInvokeEventsAsync(OnTunnelDataReceived?.GetInvocationList(), new TunnelDataGbxEventArgs
                 {
                     PlayerId = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1]),
-                    Data = (Base64) XmlRpcTypes.ToNativeValue<Base64>(call.Arguments[2])
+                    Data = (GbxBase64) XmlRpcTypes.ToNativeValue<GbxBase64>(call.Arguments[2])
                 });
                 break;
             case "ManiaPlanet.VoteUpdated":
-                await InternalInvokeEventsAsync(OnVoteUpdated?.GetInvocationList(), new VoteUpdatedEventArgs
+                await InternalInvokeEventsAsync(OnVoteUpdated?.GetInvocationList(), new VoteUpdatedGbxEventArgs
                 {
                     StateName = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1]),
@@ -275,7 +275,7 @@ public partial class GbxRemoteClient
                 });
                 break;
             case "ManiaPlanet.BillUpdated":
-                await InternalInvokeEventsAsync(OnBillUpdated?.GetInvocationList(), new BillUpdatedEventArgs
+                await InternalInvokeEventsAsync(OnBillUpdated?.GetInvocationList(), new BillUpdatedGbxEventArgs
                 {
                     BillId = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[0]),
                     State = (int) XmlRpcTypes.ToNativeValue<int>(call.Arguments[1]),
@@ -284,20 +284,20 @@ public partial class GbxRemoteClient
                 });
                 break;
             case "ManiaPlanet.PlayerAlliesChanged":
-                await InternalInvokeEventsAsync(OnPlayerAlliesChanged?.GetInvocationList(), new PlayerEventArgs
+                await InternalInvokeEventsAsync(OnPlayerAlliesChanged?.GetInvocationList(), new PlayerGbxEventArgs
                 {
                     Login = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0])
                 });
                 break;
             case "ScriptCloud.LoadData":
-                await InternalInvokeEventsAsync(OnScriptCloudLoadData?.GetInvocationList(), new ScriptCloudEventArgs
+                await InternalInvokeEventsAsync(OnScriptCloudLoadData?.GetInvocationList(), new ScriptCloudGbxEventArgs
                 {
                     Type = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     Id = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1])
                 });
                 break;
             case "ScriptCloud.SaveData":
-                await InternalInvokeEventsAsync(OnScriptCloudSaveData?.GetInvocationList(), new ScriptCloudEventArgs
+                await InternalInvokeEventsAsync(OnScriptCloudSaveData?.GetInvocationList(), new ScriptCloudGbxEventArgs
                 {
                     Type = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[0]),
                     Id = (string) XmlRpcTypes.ToNativeValue<string>(call.Arguments[1])
@@ -305,7 +305,7 @@ public partial class GbxRemoteClient
                 break;
         }
 
-        OnAnyCallback?.Invoke(this, new CallbackEventArgs<object>
+        OnAnyCallback?.Invoke(this, new CallbackGbxEventArgs<object>
         {
             Call = call,
             Parameters = (object[]) XmlRpcTypes.ToNativeValue<object>(new XmlRpcArray(call.Arguments))

--- a/src/GbxRemote.Net/GbxRemoteClient.Methods.Replays.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Methods.Replays.cs
@@ -56,9 +56,9 @@ public partial class GbxRemoteClient
     /// </summary>
     /// <param name="login"></param>
     /// <returns></returns>
-    public async Task<Base64> GetValidationReplayAsync(string login)
+    public async Task<GbxBase64> GetValidationReplayAsync(string login)
     {
-        return (Base64) XmlRpcTypes.ToNativeValue<Base64>(
+        return (GbxBase64) XmlRpcTypes.ToNativeValue<GbxBase64>(
             await CallOrFaultAsync("GetValidationReplay", login)
         );
     }

--- a/src/GbxRemote.Net/GbxRemoteClient.Methods.Script.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Methods.Script.cs
@@ -49,9 +49,9 @@ public partial class GbxRemoteClient
     ///     Returns the current settings of the mode script.
     /// </summary>
     /// <returns></returns>
-    public async Task<DynamicObject> GetModeScriptSettingsAsync()
+    public async Task<GbxDynamicObject> GetModeScriptSettingsAsync()
     {
-        return (DynamicObject) XmlRpcTypes.ToNativeValue<DynamicObject>(
+        return (GbxDynamicObject) XmlRpcTypes.ToNativeValue<GbxDynamicObject>(
             await CallOrFaultAsync("GetModeScriptSettings")
         );
     }
@@ -61,7 +61,7 @@ public partial class GbxRemoteClient
     /// </summary>
     /// <param name="modescriptSettings"></param>
     /// <returns></returns>
-    public async Task<bool> SetModeScriptSettingsAsync(DynamicObject modescriptSettings)
+    public async Task<bool> SetModeScriptSettingsAsync(GbxDynamicObject modescriptSettings)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SetModeScriptSettings", modescriptSettings)
@@ -73,7 +73,7 @@ public partial class GbxRemoteClient
     /// </summary>
     /// <param name="commands"></param>
     /// <returns></returns>
-    public async Task<bool> SendModeScriptCommandsAsync(DynamicObject commands)
+    public async Task<bool> SendModeScriptCommandsAsync(GbxDynamicObject commands)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SendModeScriptCommands", commands)
@@ -86,7 +86,7 @@ public partial class GbxRemoteClient
     /// <param name="settings"></param>
     /// <param name="modeScript"></param>
     /// <returns></returns>
-    public async Task<bool> SetModeScriptSettingsAndCommandsAsync(DynamicObject settings, DynamicObject modeScript)
+    public async Task<bool> SetModeScriptSettingsAndCommandsAsync(GbxDynamicObject settings, GbxDynamicObject modeScript)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SetModeScriptSettingsAndCommands", settings, modeScript)
@@ -97,9 +97,9 @@ public partial class GbxRemoteClient
     ///     Returns the current xml-rpc variables of the mode script.
     /// </summary>
     /// <returns></returns>
-    public async Task<DynamicObject> GetModeScriptVariablesAsync()
+    public async Task<GbxDynamicObject> GetModeScriptVariablesAsync()
     {
-        return (DynamicObject) XmlRpcTypes.ToNativeValue<DynamicObject>(
+        return (GbxDynamicObject) XmlRpcTypes.ToNativeValue<GbxDynamicObject>(
             await CallOrFaultAsync("GetModeScriptVariables")
         );
     }
@@ -109,7 +109,7 @@ public partial class GbxRemoteClient
     /// </summary>
     /// <param name="xmlRpcVar"></param>
     /// <returns></returns>
-    public async Task<bool> SetModeScriptVariablesAsync(DynamicObject xmlRpcVar)
+    public async Task<bool> SetModeScriptVariablesAsync(GbxDynamicObject xmlRpcVar)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SetModeScriptVariables", xmlRpcVar)
@@ -149,7 +149,7 @@ public partial class GbxRemoteClient
     /// <param name="filename">OPTIONAL: Name the filename relative to Scripts/directory</param>
     /// <param name="script">OPTIONAL: The script #Settings to apply.</param>
     /// <returns></returns>
-    public async Task<bool> SetServerPluginAsync(bool forceReload, string filename = null, DynamicObject script = null)
+    public async Task<bool> SetServerPluginAsync(bool forceReload, string filename = null, GbxDynamicObject script = null)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SetServerPlugin", forceReload, filename, script)
@@ -160,9 +160,9 @@ public partial class GbxRemoteClient
     ///     Get the ServerPlugin current settings.
     /// </summary>
     /// <returns></returns>
-    public async Task<DynamicObject> GetServerPluginAsync()
+    public async Task<GbxDynamicObject> GetServerPluginAsync()
     {
-        return (DynamicObject) XmlRpcTypes.ToNativeValue<DynamicObject>(
+        return (GbxDynamicObject) XmlRpcTypes.ToNativeValue<GbxDynamicObject>(
             await CallOrFaultAsync("GetServerPlugin")
         );
     }
@@ -171,9 +171,9 @@ public partial class GbxRemoteClient
     ///     Send an event to the server script. Only available to Admin.
     /// </summary>
     /// <returns></returns>
-    public async Task<DynamicObject> GetServerPluginVariablesAsync()
+    public async Task<GbxDynamicObject> GetServerPluginVariablesAsync()
     {
-        return (DynamicObject) XmlRpcTypes.ToNativeValue<DynamicObject>(
+        return (GbxDynamicObject) XmlRpcTypes.ToNativeValue<GbxDynamicObject>(
             await CallOrFaultAsync("GetServerPluginVariables")
         );
     }
@@ -210,9 +210,9 @@ public partial class GbxRemoteClient
     /// <param name="type"></param>
     /// <param name="id"></param>
     /// <returns></returns>
-    public async Task<DynamicObject> GetScriptCloudVariablesAsync(string type, string id)
+    public async Task<GbxDynamicObject> GetScriptCloudVariablesAsync(string type, string id)
     {
-        return (DynamicObject) XmlRpcTypes.ToNativeValue<DynamicObject>(
+        return (GbxDynamicObject) XmlRpcTypes.ToNativeValue<GbxDynamicObject>(
             await CallOrFaultAsync("GetScriptCloudVariables")
         );
     }
@@ -224,7 +224,7 @@ public partial class GbxRemoteClient
     /// <param name="id"></param>
     /// <param name="variables"></param>
     /// <returns></returns>
-    public async Task<bool> SetScriptCloudVariablesAsync(string type, string id, DynamicObject variables)
+    public async Task<bool> SetScriptCloudVariablesAsync(string type, string id, GbxDynamicObject variables)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("SetScriptCloudVariables")

--- a/src/GbxRemote.Net/GbxRemoteClient.Methods.Server.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.Methods.Server.cs
@@ -50,7 +50,7 @@ public partial class GbxRemoteClient
     /// <param name="fileName"></param>
     /// <param name="data"></param>
     /// <returns></returns>
-    public async Task<bool> WriteFileAsync(string fileName, Base64 data)
+    public async Task<bool> WriteFileAsync(string fileName, GbxBase64 data)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("WriteFile", fileName, data)
@@ -63,7 +63,7 @@ public partial class GbxRemoteClient
     /// <param name="id"></param>
     /// <param name="data"></param>
     /// <returns></returns>
-    public async Task<bool> TunnelSendDataToIdAsync(int id, Base64 data)
+    public async Task<bool> TunnelSendDataToIdAsync(int id, GbxBase64 data)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("TunnelSendDataToId", id, data)
@@ -77,7 +77,7 @@ public partial class GbxRemoteClient
     /// <param name="login"></param>
     /// <param name="data"></param>
     /// <returns></returns>
-    public async Task<bool> TunnelSendDataToLoginAsync(string login, Base64 data)
+    public async Task<bool> TunnelSendDataToLoginAsync(string login, GbxBase64 data)
     {
         return (bool) XmlRpcTypes.ToNativeValue<bool>(
             await CallOrFaultAsync("TunnelSendDataToLogin", login, data)

--- a/src/GbxRemote.Net/GbxRemoteClient.cs
+++ b/src/GbxRemote.Net/GbxRemoteClient.cs
@@ -16,7 +16,7 @@ public partial class GbxRemoteClient : NadeoXmlRpcClient
     /// <summary>
     ///     This is the API version the client will be using.
     /// </summary>
-    public const string DefaultApiVersion = "2022-03-21";
+    public const string DefaultApiVersion = "2023-03-24";
 
     private readonly ILogger _logger;
     private readonly GbxRemoteClientOptions _options;

--- a/src/GbxRemote.Net/Structs/TmScriptSetting.cs
+++ b/src/GbxRemote.Net/Structs/TmScriptSetting.cs
@@ -2,6 +2,6 @@
 
 namespace GbxRemoteNet.Structs;
 
-public class TmScriptSetting : DynamicObject
+public class TmScriptSetting : GbxDynamicObject
 {
 }

--- a/src/GbxRemote.Net/XmlRpc/ExtraTypes/GbxBase64.cs
+++ b/src/GbxRemote.Net/XmlRpc/ExtraTypes/GbxBase64.cs
@@ -4,21 +4,21 @@ using System.Text;
 
 namespace GbxRemoteNet.XmlRpc.ExtraTypes;
 
-public class Base64 : IEquatable<Base64>
+public class GbxBase64 : IEquatable<GbxBase64>
 {
-    public Base64(byte[] data)
+    public GbxBase64(byte[] data)
     {
         Data = data;
     }
 
-    public Base64(string data)
+    public GbxBase64(string data)
     {
         Data = Encoding.UTF8.GetBytes(data);
     }
 
     public byte[] Data { get; }
 
-    public bool Equals(Base64 other)
+    public bool Equals(GbxBase64 other)
     {
         if (other == null)
         {
@@ -33,8 +33,8 @@ public class Base64 : IEquatable<Base64>
         return Convert.ToBase64String(Data);
     }
 
-    public static Base64 FromBase64String(string data)
+    public static GbxBase64 FromBase64String(string data)
     {
-        return new Base64(Convert.FromBase64String(data));
+        return new GbxBase64(Convert.FromBase64String(data));
     }
 }

--- a/src/GbxRemote.Net/XmlRpc/ExtraTypes/GbxDynamicObject.cs
+++ b/src/GbxRemote.Net/XmlRpc/ExtraTypes/GbxDynamicObject.cs
@@ -2,6 +2,6 @@
 
 namespace GbxRemoteNet.XmlRpc.ExtraTypes;
 
-public class DynamicObject : Dictionary<string, object>
+public class GbxDynamicObject : Dictionary<string, object>
 {
 }

--- a/src/GbxRemote.Net/XmlRpc/Types/XmlRpcBase64.cs
+++ b/src/GbxRemote.Net/XmlRpc/Types/XmlRpcBase64.cs
@@ -12,16 +12,16 @@ public class XmlRpcBase64 : XmlRpcBaseType, IEquatable<XmlRpcBase64>
     /// <summary>
     ///     Native value of the XML-RPC value.
     /// </summary>
-    public Base64 Value;
+    public ExtraTypes.GbxBase64 Value;
 
-    public XmlRpcBase64(Base64 value) : base(null)
+    public XmlRpcBase64(ExtraTypes.GbxBase64 value) : base(null)
     {
         Value = value;
     }
 
     public XmlRpcBase64(XElement element) : base(element)
     {
-        Value = Base64.FromBase64String(element.Value);
+        Value = ExtraTypes.GbxBase64.FromBase64String(element.Value);
     }
 
     public bool Equals(XmlRpcBase64 other)

--- a/src/GbxRemote.Net/XmlRpc/Types/XmlRpcStruct.cs
+++ b/src/GbxRemote.Net/XmlRpc/Types/XmlRpcStruct.cs
@@ -55,7 +55,7 @@ public class XmlRpcStruct : XmlRpcBaseType, IEquatable<XmlRpcStruct>
     ///     Create a struct from a dynamic object.
     /// </summary>
     /// <param name="obj"></param>
-    public XmlRpcStruct(DynamicObject obj) : base(null)
+    public XmlRpcStruct(GbxDynamicObject obj) : base(null)
     {
         Fields = new GbxStruct();
 

--- a/src/GbxRemote.Net/XmlRpc/XmlRpcTypes.cs
+++ b/src/GbxRemote.Net/XmlRpc/XmlRpcTypes.cs
@@ -27,7 +27,7 @@ public static class XmlRpcTypes
         {XmlRpcElementNames.Struct.ToLower(), typeof(XmlRpcStruct)},
 
         // base64
-        {XmlRpcElementNames.Base64.ToLower(), typeof(XmlRpcBase64)},
+        {XmlRpcElementNames.Base64.ToLower(), typeof(Types.XmlRpcBase64)},
 
         // boolean
         {XmlRpcElementNames.Boolean.ToLower(), typeof(XmlRpcBoolean)},
@@ -78,8 +78,8 @@ public static class XmlRpcTypes
 
         var t = xmlValue.GetType();
 
-        if (t == typeof(XmlRpcBase64))
-            return ((XmlRpcBase64) xmlValue).Value;
+        if (t == typeof(Types.XmlRpcBase64))
+            return ((Types.XmlRpcBase64) xmlValue).Value;
         if (t == typeof(XmlRpcBoolean))
             return ((XmlRpcBoolean) xmlValue).Value;
         if (t == typeof(XmlRpcDateTime))
@@ -111,10 +111,10 @@ public static class XmlRpcTypes
         if (instanceType == null)
             t = typeof(T);
 
-        if (t == typeof(DynamicObject) || t == typeof(object))
+        if (t == typeof(GbxDynamicObject) || t == typeof(object))
         {
             // just copy the value if we have a dynamic object
-            DynamicObject obj = new();
+            GbxDynamicObject obj = new();
 
             foreach (var kv in xmlStruct.Fields)
                 obj.Add(kv.Key, ToNativeValue<object>(kv.Value));
@@ -193,8 +193,8 @@ public static class XmlRpcTypes
 
         var t = obj.GetType();
 
-        if (t == typeof(Base64)) // base64
-            return new XmlRpcBase64((Base64) obj);
+        if (t == typeof(GbxBase64)) // base64
+            return new Types.XmlRpcBase64((GbxBase64) obj);
         if (t == typeof(bool)) // boolean
             return new XmlRpcBoolean((bool) obj);
         if (t == typeof(DateTime)) // dateTime.iso8601
@@ -209,8 +209,8 @@ public static class XmlRpcTypes
             return new XmlRpcInteger((int) obj);
         if (t == typeof(string)) // string
             return new XmlRpcString((string) obj);
-        if (t == typeof(DynamicObject)) // struct
-            return new XmlRpcStruct((DynamicObject) obj);
+        if (t == typeof(GbxDynamicObject)) // struct
+            return new XmlRpcStruct((GbxDynamicObject) obj);
         if (t.IsArray) // array
             return ToXmlRpcArray(obj);
         if (t.IsClass) // struct


### PR DESCRIPTION
- Includes update for the new API version `2023-03-24`
- Includes name changes for some of the classes which were too generic.

Due to incompatible API changes, this pushes the library to semantic version 4.0.0.

